### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,31 +7,9 @@ services:
      - "8080:8080"
     depends_on:
      - db
-    environment:
-     - DB_HOST=db
-     - DB_USER=ecoov
-     - DB_NAME=ecoov
-     - DB_PASS=ecoov
-     - DB_PORT=5432
-     - SMTP_HOST=smtp.mailgun.org
-     - SMTP_USER=postmaster@xxxxxxxxx.mailgun.org
-     - SMTP_FROM=postmaster@xxxxxxxxx.mailgun.org
-     - SMTP_PASS=xxxxxxxxx
-     - PUBLICURL=http://localhost:8080
-     - PORT=8080
-     - AWS_ACCESS_KEY_ID=xxxxxxxx
-     - AWS_SECRET_ACCESS_KEY=xxxxxxxx
-     - AWS_REGION=eu-central-1
-     - BUCKET_NAME=boost
+    links:
+     - db
   nginx:
     image: nginx
-    container_name: boost-nginx
   db:
     image: mongo
-    container_name: boost-mongo
-    ports:
-      - "27017:27017"
-    environment:
-     - DB_PASSWORD=boost
-     - DB_USER=boost
-     - DB_DB=boost


### PR DESCRIPTION
Poznámky:
- u kontejneru nemusíš specifikovat porty, pokud je nechceš vystavit navenek, asi případ kontejneru `db` (pokud se chceš do databáze dostat třeba nějakým db gui toolem, pak to tam nech)
- sekci environments jsem smazal, protože to byly proměnné speciálně pro OV projekt
- u generických kontejnerů, stažených od jinud (jako je `mongo`) není nutné uvádět jméno - kontejner není ničím specifický od toho původního
- teď to pro tebe nejdůležitější, networking - https://docs.docker.com/compose/networking/
V kontejneru `web` má kontejner db hostname db (je to tak defaultně a zároveň jsem to přidal s pomocí `links`, lze si i specifikovat alias). Kontejner mongo je exposnutý na portu 27017, takže jej v kontejneru `web` uvidíš jako `db:27017` nebo url `mongo://db:27017`.

Btw netestoval jsem to, nějak mi to nešlo rozběhnout.